### PR TITLE
Revert "chore: add systems.flakeExposed". That was a bad idea

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
     {
       overlays = import ./overlays.nix { inherit (inputs) outputs; };
     }
-    // flake-utils.lib.eachSystem nixpkgs.lib.systems.flakeExposed (
+    // flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (
       system:
       let
         pkgs = import nixpkgs {


### PR DESCRIPTION
Reverts ViZiD/picokeys-nix#10. That was a bad idea.